### PR TITLE
Prompts user to grant `READ_CONTACTS` permission

### DIFF
--- a/packages/clients/android/app/src/main/java/com/cx/goatlin/LoginActivity.kt
+++ b/packages/clients/android/app/src/main/java/com/cx/goatlin/LoginActivity.kt
@@ -18,7 +18,10 @@ import android.widget.ArrayAdapter
 import android.widget.TextView
 import java.util.ArrayList
 import android.content.*
+import android.content.pm.PackageManager
 import android.support.annotation.RequiresApi
+import android.support.v4.app.ActivityCompat
+import android.support.v4.content.ContextCompat
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -40,6 +43,7 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         PreferenceHelper.init(applicationContext)
 
         setContentView(R.layout.activity_login)
@@ -57,6 +61,14 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
         sign_up_button.setOnClickListener {
             val intent = Intent(this, SignupActivity::class.java)
             startActivity(intent)
+        }
+    }
+
+    private fun checkAndPromptUserToGrantPermissions() {
+        if (ContextCompat.checkSelfPermission(
+                this,android.Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(
+                this, arrayOf(android.Manifest.permission.READ_CONTACTS), 1)
         }
     }
 
@@ -164,6 +176,7 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
 
     @RequiresApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     override fun onCreateLoader(i: Int, bundle: Bundle?): Loader<Cursor> {
+        checkAndPromptUserToGrantPermissions();
         return CursorLoader(this,
                 // Retrieve data rows for the device user's 'profile' contact.
                 Uri.withAppendedPath(ContactsContract.Profile.CONTENT_URI,

--- a/packages/clients/android/app/src/main/java/com/cx/goatlin/LoginActivity.kt
+++ b/packages/clients/android/app/src/main/java/com/cx/goatlin/LoginActivity.kt
@@ -43,7 +43,6 @@ class LoginActivity : AppCompatActivity(), LoaderCallbacks<Cursor> {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         PreferenceHelper.init(applicationContext)
 
         setContentView(R.layout.activity_login)


### PR DESCRIPTION
Before the application needs to use the `READ_CONTACTS` permission, it checks whether the permission has been granted and, if not, prompts user to grant it.
This prevents app from crashing on launch.