### PR TITLE
Fixes Content Providers' Authority

### DIFF
--- a/packages/clients/android/app/src/main/java/com/cx/goatlin/AccountProvider.kt
+++ b/packages/clients/android/app/src/main/java/com/cx/goatlin/AccountProvider.kt
@@ -86,7 +86,7 @@ class AccountProvider : ContentProvider() {
 
 
     companion object {
-        private val AUTHORITY = "com.cx.vulnerablekotlinapp.accounts"
+        private val AUTHORITY = "com.cx.goatlin.accounts"
         private val ACCOUNTS_TABLE = "Accounts"
         val CONTENT_URI : Uri = Uri.parse("content://" + AUTHORITY + "/" +
                 ACCOUNTS_TABLE)

--- a/packages/clients/android/app/src/main/java/com/cx/goatlin/NotesProvider.kt
+++ b/packages/clients/android/app/src/main/java/com/cx/goatlin/NotesProvider.kt
@@ -83,7 +83,7 @@ class NotesProvider : ContentProvider() {
 
 
     companion object {
-        private val AUTHORITY = "com.cx.vulnerablekotlinapp.notes"
+        private val AUTHORITY = "com.cx.goatlin.notes"
         private val NOTES_TABLE = "Notes"
         val CONTENT_URI : Uri = Uri.parse("content://" + AUTHORITY + "/" +
                 NOTES_TABLE)


### PR DESCRIPTION
Changes authority from `com.cx.vulnerablekotlinapp` to `com.cx.goatlin` to fix access to content providers, by matching what's declared on `AndroidManifest.xml`.